### PR TITLE
Add planning HTML with CSV export button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <title>Guardias Urología HUMV - Sistema de Planificación v4.0</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="min-h-screen bg-gray-100">
+  <header class="gradient-bg shadow-lg p-6 no-print">
+    <div class="flex justify-between items-center max-w-7xl mx-auto">
+      <div>
+        <h1 class="text-2xl font-bold text-white">Guardias Urología HUMV</h1>
+        <p class="text-blue-100 text-sm">Sistema de Planificación - Versión 4.0</p>
+        <div id="estado-actual" class="mt-2">
+          <span class="estado-borrador px-3 py-1 rounded-full text-xs font-semibold">
+            🟡 BORRADOR - Sin confirmar
+          </span>
+        </div>
+      </div>
+      <div class="flex space-x-3" id="botones-principales"></div>
+    </div>
+  </header>
+
+  <div class="max-w-7xl mx-auto p-6">
+    <div id="tab-horario" class="card p-6">
+      <div class="flex flex-wrap items-center gap-4 mb-6">
+        <div class="flex items-center space-x-2">
+          <label for="select-mes" class="font-semibold text-gray-700">Mes:</label>
+          <select id="select-mes" class="border border-gray-300 rounded-lg p-2">
+            <option value="0">Enero</option>
+            <option value="1">Febrero</option>
+            <option value="2">Marzo</option>
+            <option value="3">Abril</option>
+            <option value="4">Mayo</option>
+            <option value="5">Junio</option>
+            <option value="6">Julio</option>
+            <option value="7">Agosto</option>
+            <option value="8">Septiembre</option>
+            <option value="9">Octubre</option>
+            <option value="10">Noviembre</option>
+            <option value="11">Diciembre</option>
+          </select>
+        </div>
+        <div class="flex items-center space-x-2">
+          <label for="select-anio" class="font-semibold text-gray-700">Año:</label>
+          <select id="select-anio" class="border border-gray-300 rounded-lg p-2"></select>
+        </div>
+        <button id="btn-generar-horario" class="bg-blue-600 text-white px-6 py-2 rounded-lg">Generar Horario</button>
+      </div>
+      <div class="overflow-auto border border-gray-200 rounded-lg">
+        <table class="min-w-full table-auto border-collapse" id="tabla-horario">
+          <thead>
+            <tr class="bg-gray-50 text-gray-700">
+              <th class="border-b border-gray-200 p-3">Fecha</th>
+              <th class="border-b border-gray-200 p-3">Día</th>
+              <th class="border-b border-gray-200 p-3">Staff 1</th>
+              <th class="border-b border-gray-200 p-3">Staff 2</th>
+              <th class="border-b border-gray-200 p-3">Residente</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card p-6 mt-8" id="export-section">
+      <h3 class="text-lg font-semibold mb-4 text-gray-700">Opciones de Exportación</h3>
+      <div class="space-y-4">
+        <button id="btn-export-ics" class="w-full google-btn text-white px-4 py-3 rounded-lg" disabled>
+          📅 Descargar archivo .ics (Google Calendar)
+        </button>
+        <button id="btn-exportar-csv" class="w-full bg-yellow-600 text-white px-4 py-3 rounded-lg hover:bg-yellow-700" disabled>
+          📄 Exportar CSV
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,31 @@
+const ESTADOS = {
+  VACIO: 'vacio',
+  BORRADOR: 'borrador',
+  CONFIRMADO: 'confirmado',
+  DEFINITIVO: 'definitivo'
+};
+
+let estadoActual = ESTADOS.VACIO;
+
+function generarAnios() {
+  const sel = document.getElementById('select-anio');
+  const actual = new Date().getFullYear();
+  for (let i = actual; i <= actual + 2; i++) {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = i;
+    sel.appendChild(opt);
+  }
+}
+
+function inicializar() {
+  generarAnios();
+  document.getElementById('select-anio').value = new Date().getFullYear();
+  document.getElementById('btn-exportar-csv').addEventListener('click', exportarCSV);
+}
+
+document.addEventListener('DOMContentLoaded', inicializar);
+
+function exportarCSV() {
+  alert('Función de exportar CSV aún en desarrollo.');
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,39 @@
+.tab-active {
+  background: linear-gradient(135deg, #3b82f6, #1e40af);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+}
+.gradient-bg {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+.google-gradient {
+  background: linear-gradient(135deg, #4285f4 0%, #34a853 25%, #fbbc05 50%, #ea4335 75%);
+}
+@media print {
+  .no-print { display:none !important; }
+  tr.weekend { background-color:#fff7ed !important; }
+  body { background:white !important; }
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06);
+  transition: all 0.2s ease-in-out;
+}
+.card:hover {
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05);
+}
+.balance-indicator { display:inline-block; padding:2px 6px; border-radius:4px; font-size:0.75rem; font-weight:600; }
+.balance-good { background-color:#dcfce7; color:#166534; }
+.balance-warning { background-color:#fef3c7; color:#92400e; }
+.balance-bad { background-color:#fee2e2; color:#991b1b; }
+.estado-borrador { background-color:#fef3c7; color:#92400e; }
+.estado-confirmado { background-color:#fed7aa; color:#9a3412; }
+.estado-definitivo { background-color:#dcfce7; color:#166534; }
+.pulse { animation: pulse 2s cubic-bezier(0.4,0,0.6,1) infinite; }
+@keyframes pulse { 0%,100% {opacity:1;} 50% {opacity:.5;} }
+.google-btn { background: linear-gradient(135deg, #4285f4, #34a853); transition: all 0.3s ease; }
+.google-btn:hover { transform: translateY(-1px); box-shadow: 0 4px 12px rgba(66,133,244,0.3); }
+.campo-bloqueado { background-color:#f3f4f6; cursor:not-allowed; opacity:0.7; }
+.campo-editable { background-color:white; cursor:pointer; }


### PR DESCRIPTION
## Summary
- add HTML planning page in Spanish
- add dynamic year generation
- add export CSV button and hook
- split custom styles and JS into separate files

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686e34817104832499fdbb0246be0116